### PR TITLE
Fix counter and add footnote on SBA and EFF

### DIFF
--- a/presentation/presentation.qmd
+++ b/presentation/presentation.qmd
@@ -129,7 +129,7 @@ $\Rightarrow$ Constructing a single latent measure of **U.S. alignment** and a s
 
 ## Empirical Strategy (3/3)
 
-- Outcome Variables:
+- Outcome Variables[^2]:
 
   - IMF loan to GDP ratio, IMF participation rate
 
@@ -146,6 +146,8 @@ $\Rightarrow$ Constructing a single latent measure of **U.S. alignment** and a s
   - GDP, Growth
 
   - Reserves, OECD
+
+[^2]: We only include Stand-By Arrangements (SBA) and Extended Fund Facility (EFF) programmes for comparability with prior studies [@lipscy2018; @barro2005; @dreher2006].
 
 ## Model Specification
 

--- a/presentation/presentation.qmd
+++ b/presentation/presentation.qmd
@@ -127,7 +127,7 @@ $\Rightarrow$ Constructing a single latent measure of **U.S. alignment** and a s
 
 [^1]: We operationalize "Europe" as the United Kingdom, France, and Germany — the three largest European economies with the most institutional weight in the IMF.
 
-## Empirical Strategy (2/3)
+## Empirical Strategy (3/3)
 
 - Outcome Variables:
 


### PR DESCRIPTION
This pull request makes a minor update to the `presentation.qmd` file, clarifying the empirical strategy section and adding a methodological footnote for outcome variable selection.

- Documentation and Clarity Improvements:
  * Updated the empirical strategy section heading from "Empirical Strategy (2/3)" to "Empirical Strategy (3/3)" and clarified the outcome variables list.
  * Added a footnote specifying that only Stand-By Arrangements (SBA) and Extended Fund Facility (EFF) IMF programs are included, with references to prior studies for methodological consistency.